### PR TITLE
Order list by number

### DIFF
--- a/IdeaFight/Compete.elm
+++ b/IdeaFight/Compete.elm
@@ -50,7 +50,7 @@ topValuesSoFar forest =
   let topValues = Forest.topN forest
   in case topValues of
       []        -> text "We haven't found the best idea yet - keep choosing!"
-      topValues -> div [] [ text "Your best ideas:", ul [] <| List.map (\value -> li [] [ text value ]) topValues ]
+      topValues -> div [] [ text "Your best ideas:", ol [] <| List.map (\value -> li [] [ text value ]) topValues ]
 
 view : Model -> Html Msg
 view model =


### PR DESCRIPTION
I change the `ul` to `ol` this way the list of best ideas have a number.
It's easier to follow the list and translate the result in another kanban system for example.

Great app by the way, I currently use it in my work
